### PR TITLE
Add retry utility tests and document testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ const { result, error, attempts } = await retry(() => callExternalAPI(), { retri
 
 ```bash
 npm run typecheck
+npm run lint
 npm run build
 npm test
 ```

--- a/src/utils/async-utils.test.ts
+++ b/src/utils/async-utils.test.ts
@@ -35,5 +35,24 @@ describe('retry', () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ result: 'ok', attempts: 1 });
   });
-});
 
+  it('waits the specified delay between retries', async () => {
+    jest.useFakeTimers();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('ok');
+
+    const promise = retry(fn, { retries: 2, delayMs: 100 });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ result: 'ok', attempts: 2 });
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for async retry helper
- document how to run tests in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd68dfd88324a7f8139fdf103977