### PR TITLE
feat: add mock logger service and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './logger/gcp-logger.module';
 export * from './logger/gcp-logger.service';
+export * from './logger/mock-logger.service';
 export * from './config/app-config.module';
 export * from './config/app-config.service';
 export * from './config/config-validation';

--- a/src/logger/gcp-logger.service.test.ts
+++ b/src/logger/gcp-logger.service.test.ts
@@ -1,0 +1,35 @@
+import { PassThrough } from 'stream';
+import { GcpLoggerService, als } from './gcp-logger.service';
+
+describe('GcpLoggerService', () => {
+  const createLogger = () => {
+    const stream = new PassThrough();
+    const logs: any[] = [];
+    stream.on('data', (chunk) => {
+      const lines = chunk
+        .toString()
+        .split('\n')
+        .filter(Boolean);
+      for (const line of lines) {
+        logs.push(JSON.parse(line));
+      }
+    });
+    const logger = new GcpLoggerService({ serviceName: 'test', env: 'production' }, stream);
+    return { logger, logs };
+  };
+
+  it('maps levels to severity', () => {
+    const { logger, logs } = createLogger();
+    logger.error('boom');
+    expect(logs[0].severity).toBe('ERROR');
+  });
+
+  it('includes trace and spanId from async local storage', () => {
+    const { logger, logs } = createLogger();
+    als.run({ trace: 'trace-1', spanId: 'span-1' }, () => {
+      logger.log('hello');
+    });
+    expect(logs[0]['logging.googleapis.com/trace']).toBe('trace-1');
+    expect(logs[0]['logging.googleapis.com/spanId']).toBe('span-1');
+  });
+});

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -5,3 +5,4 @@ export * from './logging.interceptor';
 export * from './all-exceptions.filter';
 export * from './decorators/log-context.decorator';
 export * from './opentelemetry';
+export * from './mock-logger.service';

--- a/src/logger/mock-logger.service.test.ts
+++ b/src/logger/mock-logger.service.test.ts
@@ -1,0 +1,18 @@
+import { MockLoggerService } from './mock-logger.service';
+
+describe('MockLoggerService', () => {
+  it('records messages by level', () => {
+    const logger = new MockLoggerService();
+    logger.log('info');
+    logger.error('error', { detail: true });
+    logger.warn('warn');
+    logger.debug('debug');
+    logger.verbose('verbose');
+
+    expect(logger.logs).toEqual([[ 'info' ]]);
+    expect(logger.errors).toEqual([[ 'error', { detail: true } ]]);
+    expect(logger.warnings).toEqual([[ 'warn' ]]);
+    expect(logger.debugs).toEqual([[ 'debug' ]]);
+    expect(logger.verboses).toEqual([[ 'verbose' ]]);
+  });
+});

--- a/src/logger/mock-logger.service.ts
+++ b/src/logger/mock-logger.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
+
+@Injectable()
+export class MockLoggerService implements NestLoggerService {
+  logs: any[][] = [];
+  errors: any[][] = [];
+  warnings: any[][] = [];
+  debugs: any[][] = [];
+  verboses: any[][] = [];
+  bindings: Record<string, any> = {};
+
+  log(message: any, ...optionalParams: any[]) {
+    this.logs.push([message, ...optionalParams]);
+  }
+  error(message: any, ...optionalParams: any[]) {
+    this.errors.push([message, ...optionalParams]);
+  }
+  warn(message: any, ...optionalParams: any[]) {
+    this.warnings.push([message, ...optionalParams]);
+  }
+  debug(message: any, ...optionalParams: any[]) {
+    this.debugs.push([message, ...optionalParams]);
+  }
+  verbose(message: any, ...optionalParams: any[]) {
+    this.verboses.push([message, ...optionalParams]);
+  }
+
+  setBindings(bindings: Record<string, any>) {
+    this.bindings = bindings;
+  }
+
+  child(bindings: Record<string, any>) {
+    this.bindings = { ...this.bindings, ...bindings };
+    return this;
+  }
+}


### PR DESCRIPTION
## Summary
- add MockLoggerService to capture log messages
- export mock logger for library consumers
- test GcpLoggerService behavior and mock implementation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca8bfbb08324a65963728ea7642d